### PR TITLE
Added options to allow compilation on OS X

### DIFF
--- a/src/arangodb-driver.pro
+++ b/src/arangodb-driver.pro
@@ -15,6 +15,12 @@ else {
     QMAKE_CXXFLAGS += -std=c++11
 }
 
+macx {
+    QMAKE_CXXFLAGS += -stdlib=libc++
+    LIBS += -stdlib=libc++
+    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.7
+}
+
 TARGET = arangodb-driver
 TEMPLATE = lib
 


### PR DESCRIPTION
I had problems compiling the driver on OS X, so I changed the qmake file. Since the library uses C++11 features, the code won't compile on OS X 10.6 or earlier.
